### PR TITLE
Add support for local Codespaces dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ To test the sample:
     This will launch the app, where you can use example context and instructions to get started. 
     On the 'Creative Team' page you can examine the output of each agent by clicking on it. The app should look like this:
 
+    Note: If you run in Codespaces, you will have to change the visibility of the API's 8080 port to `public` in VS Code's `PORTS` tab.
+
    The getting started tab to send your instructions and context to the prompt:
    
     ![getting started](images/get_started_page.png)

--- a/src/web/src/constants.ts
+++ b/src/web/src/constants.ts
@@ -1,4 +1,13 @@
+import { githubDevSubsPort } from "./utils/ghutils";
+
 const hostname = window.location.hostname;
-const apiEndpoint = (hostname === 'localhost' || hostname === '127.0.0.1') ? "http://localhost:8080/get_article" : "api/get_article";
+const apiPort = 8080
+
+
+const apiEndpoint = (hostname === 'localhost' || hostname === '127.0.0.1')
+    ? `http://localhost:${apiPort}/get_article`
+    : hostname.endsWith('github.dev') 
+    ? `${githubDevSubsPort(hostname, apiPort)}/get_article`
+    : "api/get_article";
 
 export { apiEndpoint };

--- a/src/web/src/utils/ghutils.ts
+++ b/src/web/src/utils/ghutils.ts
@@ -1,0 +1,11 @@
+function githubDevSubsPort(hostname: string, port: number): string {
+    const regex = /-[0-9]{4,6}/gm;
+    const subst = `-${port}`;
+    let result = hostname.replace(regex, subst);
+    if (!result.startsWith("https://")) {
+        result = "https://"+ result;
+    }
+    return result;    
+}
+
+export { githubDevSubsPort }


### PR DESCRIPTION
Notes:
- CORS was already configured so nothing to do there
- The domain resolution was not accounting for the github.dev specifics (port in the domain name)
- devcontainer port forwarding for the API's 8080 must be public, otherwise, github strips the CORS headers set by the Python app.

Changes:
- Added instruction in README to set 8080 port to public
- Added support to resolve the API's domain when on `github.dev` domain.
