### PR TITLE
Fix AppInsights configuration + tool_calls + Docker image date TAG

### DIFF
--- a/infra/core/monitor/applicationinsights.bicep
+++ b/infra/core/monitor/applicationinsights.bicep
@@ -25,7 +25,7 @@ module applicationInsightsDashboard 'applicationinsights-dashboard.bicep' = if (
   }
 }
 
-output connectionString string = replace(applicationInsights.properties.ConnectionString,applicationInsights.properties.InstrumentationKey,'00000000-0000-0000-0000-000000000000')
+output connectionString string = applicationInsights.properties.ConnectionString
 output id string = applicationInsights.id
 output instrumentationKey string = applicationInsights.properties.InstrumentationKey
 output name string = applicationInsights.name

--- a/infra/hooks/postprovision.sh
+++ b/infra/hooks/postprovision.sh
@@ -4,9 +4,10 @@
 azd env get-values > .env
 
 echo  "Building creativeagentapi:latest..."
+TAG=$(date +%Y%m%d-%H%M%S)
 az login --use-device-code
-az acr build --subscription ${AZURE_SUBSCRIPTION_ID} --registry ${AZURE_CONTAINER_REGISTRY_NAME} --image creativeagentapi:latest --file ./src/Dockerfile.fat ./src/
-image_name="${AZURE_CONTAINER_REGISTRY_NAME}.azurecr.io/creativeagentapi:latest"
+az acr build --subscription ${AZURE_SUBSCRIPTION_ID} --registry ${AZURE_CONTAINER_REGISTRY_NAME} --image creativeagentapi:${TAG} --file ./src/Dockerfile.fat ./src/
+image_name="${AZURE_CONTAINER_REGISTRY_NAME}.azurecr.io/creativeagentapi:${TAG}"
 az containerapp update --subscription ${AZURE_SUBSCRIPTION_ID} --name ${SERVICE_ACA_NAME} --resource-group ${AZURE_RESOURCE_GROUP} --image ${image_name}
 az containerapp ingress update --subscription ${AZURE_SUBSCRIPTION_ID} --name ${SERVICE_ACA_NAME} --resource-group ${AZURE_RESOURCE_GROUP} --target-port 5000
 

--- a/src/api/api/logging.py
+++ b/src/api/api/logging.py
@@ -17,8 +17,8 @@ def log_output(*args):
 
 def init_logging(sampling_rate=1.0, log_level=DEFAULT_LOG_LEVEL):
     # Enable logging to app insights if a connection string is provided
-    if 'APPLICATIONINSIGHTS_CONNECTION_STRING' in os.environ:
-        connection_string=os.environ['APPLICATIONINSIGHTS_CONNECTION_STRING']
+    if 'APPINSIGHTS_CONNECTIONSTRING' in os.environ:
+        connection_string=os.environ['APPINSIGHTS_CONNECTIONSTRING']
         if connection_string != "":
             inject_openai_api()
             trace.set_tracer_provider(TracerProvider(sampler=ParentBasedTraceIdRatio(sampling_rate)))

--- a/src/api/api/logging.py
+++ b/src/api/api/logging.py
@@ -16,19 +16,24 @@ def log_output(*args):
     logging.log(DEFAULT_LOG_LEVEL, *args)
 
 def init_logging(sampling_rate=1.0, log_level=DEFAULT_LOG_LEVEL):
+    logging.basicConfig(
+        level=log_level, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+
     # Enable logging to app insights if a connection string is provided
     if 'APPINSIGHTS_CONNECTIONSTRING' in os.environ:
         connection_string=os.environ['APPINSIGHTS_CONNECTIONSTRING']
         if connection_string != "":
+            log_output(f"AppInsights connection string = {connection_string}")
             inject_openai_api()
             trace.set_tracer_provider(TracerProvider(sampler=ParentBasedTraceIdRatio(sampling_rate)))
             trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(AzureMonitorTraceExporter(connection_string=connection_string)))
+            log_output("AppInsights configured")
+    else:
+        log_output("AppInsights not configured")
 
     # Enable logging locally if the below variable is set
     if 'PROMPTFLOW_TRACING_SERVER' in os.environ and os.environ['PROMPTFLOW_TRACING_SERVER'] != 'false':
         start_pf_tracing()
 
-    logging.basicConfig(
-        level=log_level, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
     log_output("Logging initialized.")


### PR DESCRIPTION
- Fix AppInsights env vars
- Use a date based TAG instead of latest to force image updates during `azd up`
- Fixed error when researcher doesn't return `tool_calls`
