### PR TITLE
Requests to context and adding a Reranker Score Threshold

### DIFF
--- a/src/api/api/agents/orchestrator.py
+++ b/src/api/api/agents/orchestrator.py
@@ -13,9 +13,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 @trace
-def get_research(request, instructions, feedback):
+def get_research(context, instructions, feedback):
     research_result = researcher.research(
-        request=request,
+        context=context,
         instructions=instructions,
         feedback=feedback
     )
@@ -26,9 +26,9 @@ def get_research(request, instructions, feedback):
 
 
 @trace
-def get_writer(request, feedback, instructions, research=[], products=[]):
+def get_writer(context, feedback, instructions, research=[], products=[]):
     writer_reponse = writer.write(
-        request=request, feedback=feedback, instructions=instructions, research=research, products=products
+        context=context, feedback=feedback, instructions=instructions, research=research, products=products
     )
     print(json.dumps(writer_reponse, indent=2))
     return writer_reponse
@@ -77,7 +77,7 @@ def regenerate_process(editor_response, context, instructions, product_documenat
 
 @trace
 def write_article(request, instructions, evaluate=False):
-    log_output("Article generation started for request: %s, instructions: %s", request, instructions)
+    log_output(f"Article generation started for {request} {instructions}")
 
     feedback = "No Feedback"
 
@@ -132,7 +132,7 @@ def write_article(request, instructions, evaluate=False):
 
     if evaluate:
         evaluate_article_in_background(
-            request=request,
+            context=request,
             instructions=instructions,
             research=research_result,
             products=product_documenation,

--- a/src/api/api/agents/product/ai_search.py
+++ b/src/api/api/agents/product/ai_search.py
@@ -14,6 +14,7 @@ def retrieve_documentation(
     request: str,
     index_name: str,
     embedding: List[float],
+    reranker_score_threshold: float = 0.5  # Default threshold value
 ) -> str:
     
     search_client = SearchClient(
@@ -44,6 +45,7 @@ def retrieve_documentation(
             "url": doc["url"],
         }
         for doc in results
+        if doc["@search.reranker_score"] >= reranker_score_threshold
     ]
 
     return docs

--- a/src/api/api/agents/researcher/researcher.prompty
+++ b/src/api/api/agents/researcher/researcher.prompty
@@ -43,7 +43,7 @@ Your queries should be descriptive and match the context and feedback provided.
 Use this context to formulate your queries, market, and tools you will use to description
 your research:
 
-{{request}}
+{{context}}
 
 # Feedback
 Use this feedback to help you refine your queries and responses - if there is any feedback:

--- a/src/api/api/agents/researcher/researcher.py
+++ b/src/api/api/agents/researcher/researcher.py
@@ -81,7 +81,7 @@ def find_news(query, market="en-US"):
     return articles
 
 @trace
-def execute(request: str, instructions: str, feedback: str = ""):
+def execute(context: str, instructions: str, feedback: str = ""):
     """Assign a research task to a researcher"""
     functions = {
         "find_information": find_information,
@@ -100,7 +100,7 @@ def execute(request: str, instructions: str, feedback: str = ""):
         "parameters": {"max_tokens": 512}
     }
     prompty_obj = Prompty.load(folder + "/researcher.prompty", model=override_model)
-    results = prompty_obj(request=request, instructions=instructions, feedback=feedback)
+    results = prompty_obj(context=context, instructions=instructions, feedback=feedback)
 
     research = []
 
@@ -156,8 +156,8 @@ def process(research):
     }
 
 
-def research(request, instructions, feedback: str = ""):
-    r = execute(request=request, instructions=instructions, feedback=feedback)
+def research(context, instructions, feedback: str = ""):
+    r = execute(context=context, instructions=instructions, feedback=feedback)
     p = process(r)
     return p
 

--- a/src/api/api/agents/writer/writer.py
+++ b/src/api/api/agents/writer/writer.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 folder = Path(__file__).parent.absolute().as_posix()
 
-def execute(request, feedback, instructions, research, products):
+def execute(context, feedback, instructions, research, products):
     # Load prompty with AzureOpenAIModelConfiguration override
     configuration = AzureOpenAIModelConfiguration(
         azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"),
@@ -25,7 +25,7 @@ def execute(request, feedback, instructions, research, products):
     prompty_file = folder + "/writer.prompty"
     loaded_prompty = Flow.load(prompty_file, model=override_model)
     result = loaded_prompty(
-        request=request,
+        context=context,
         feedback=feedback,
         instructions=instructions,
         research=research,
@@ -49,9 +49,9 @@ def process(writer):
         "feedback": feedback,
     }
 
-def write(request, feedback, instructions, research, products):
+def write(context, feedback, instructions, research, products):
     result = execute(
-        request=request,
+        context=context,
         feedback=feedback,
         instructions=instructions,
         research=research,
@@ -67,12 +67,12 @@ if __name__ == "__main__":
     # feedback = "Research Feedback:\nAdditional specifics on how each phase of his education directly influenced particular career decisions or leadership styles at Microsoft would enhance the narrative. Information on key projects or initiatives that Nadella led, correlating to his expertise gained from his various degrees, would add depth to the discussion on the interplay between his education and career milestones."
     # instructions = "Can you find the relevant information on both him as a person and what he studied and maybe some news articles?"
     # research = []
-    request = sys.argv[1]
+    context = sys.argv[1]
     feedback = sys.argv[2]
     instructions = sys.argv[3]
     research = json.dumps(sys.argv[4])
     result = execute(
-        request=str(request),
+        context=str(context),
         feedback=str(feedback),
         instructions=str(instructions),
         research=research,

--- a/src/api/api/evaluate/evaluators.py
+++ b/src/api/api/evaluate/evaluators.py
@@ -45,10 +45,10 @@ def evaluate_article(data, trace_context):
 
         print("results: ", resultsJson)
 
-def evaluate_article_in_background(request, instructions, research, products, article):
+def evaluate_article_in_background(context, instructions, research, products, article):
     eval_data = {
         "query": json.dumps({
-            "request": request,
+            "context": context,
             "instructions": instructions,
         }),
         "context": json.dumps({

--- a/src/api/api/get_article.py
+++ b/src/api/api/get_article.py
@@ -22,7 +22,6 @@ def _create_json_response(type, contents):
 def get_article():
     context = request.args.get("context")
     instructions = request.args.get("instructions")
-
     evaluate = False
     span = trace.get_current_span()
     if (span.is_recording):


### PR DESCRIPTION
This PR should fix the issues with incorrect results being returned.
Previously we were naming the parameter being passed to the researcher, writer and evaluator `requests`. This has adverse effects on the outputs as the prompty and promptflow trace expects `context` as a parameter. Changing this makes a significant difference. I have also added a reranker threshold so that if the query has nothing to do with the outdoor contoso products no products are included in the results. 