### PR TITLE
Fix ACA deployment with 2 containers approach

### DIFF
--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -6,8 +6,7 @@ param identityName string
 param identityId string
 param containerAppsEnvironmentName string
 param containerRegistryName string
-param serviceName string = 'aca'
-
+param serviceName string = 'api'
 param openAi_35_turbo_DeploymentName string
 param openAi_4_DeploymentName string
 param openAi_4_eval_DeploymentName string

--- a/infra/app/web.bicep
+++ b/infra/app/web.bicep
@@ -7,6 +7,7 @@ param identityId string
 param containerAppsEnvironmentName string
 param containerRegistryName string
 param serviceName string = 'web'
+param apiEndpoint string
 
 
 module app '../core/host/container-app-upsert.bicep' = {
@@ -23,6 +24,10 @@ module app '../core/host/container-app-upsert.bicep' = {
       {
         name: 'AZURE_CLIENT_ID'
         value: identityId
+      }
+      {
+        name: 'API_ENDPOINT'
+        value: apiEndpoint
       }
     ]
     targetPort: 80

--- a/infra/app/web.bicep
+++ b/infra/app/web.bicep
@@ -1,0 +1,34 @@
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+
+param identityName string
+param identityId string
+param containerAppsEnvironmentName string
+param containerRegistryName string
+param serviceName string = 'web'
+
+
+module app '../core/host/container-app-upsert.bicep' = {
+  name: '${serviceName}-container-app-module'
+  params: {
+    name: name
+    location: location
+    tags: union(tags, { 'azd-service-name': serviceName })
+    identityName: identityName
+    identityType: 'UserAssigned'
+    containerAppsEnvironmentName: containerAppsEnvironmentName
+    containerRegistryName: containerRegistryName
+    env: [
+      {
+        name: 'AZURE_CLIENT_ID'
+        value: identityId
+      }
+    ]
+    targetPort: 80
+  }
+}
+
+output SERVICE_ACA_NAME string = app.outputs.name
+output SERVICE_ACA_URI string = app.outputs.uri
+output SERVICE_ACA_IMAGE_NAME string = app.outputs.imageName

--- a/infra/hooks/postprovision.sh
+++ b/infra/hooks/postprovision.sh
@@ -19,7 +19,7 @@ acr_build () {
 
 TAG=$(date +%Y%m%d-%H%M%S)
 acr_build creativeagentapi:${TAG} ${API_SERVICE_ACA_NAME} ./src/api/ 80
-acr_build creativeagentweb:${TAG} ${WEB_SERVICE_ACA_NAME} ./src/web/ 8080
+acr_build creativeagentweb:${TAG} ${WEB_SERVICE_ACA_NAME} ./src/web/ 80
 
 # Retrieve service names, resource group name, and other values from environment variables
 resourceGroupName=$AZURE_RESOURCE_GROUP

--- a/infra/hooks/postprovision.sh
+++ b/infra/hooks/postprovision.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Output environment variables to .env file using azd env get-values
 azd env get-values > .env
 

--- a/infra/hooks/postprovision.sh
+++ b/infra/hooks/postprovision.sh
@@ -18,7 +18,16 @@ acr_build () {
 }
 
 TAG=$(date +%Y%m%d-%H%M%S)
+echo  "az login in for api..."
+az login --use-device-code
 acr_build creativeagentapi:${TAG} ${API_SERVICE_ACA_NAME} ./src/api/ 80
+# AZ LOGIN CHECK
+EXPIRED_TOKEN=$(az ad signed-in-user show --query 'id' -o tsv 2>/dev/null || true)
+# Check if the user is not logged in and if not login again
+if [[ -z "$EXPIRED_TOKEN" ]]; then
+    echo  "az login in for web..."
+    az login --use-device-code
+fi
 acr_build creativeagentweb:${TAG} ${WEB_SERVICE_ACA_NAME} ./src/web/ 80
 
 # Retrieve service names, resource group name, and other values from environment variables

--- a/infra/hooks/postprovision.sh
+++ b/infra/hooks/postprovision.sh
@@ -3,14 +3,21 @@
 # Output environment variables to .env file using azd env get-values
 azd env get-values > .env
 
-echo  "Building creativeagentapi:latest..."
-TAG=$(date +%Y%m%d-%H%M%S)
-az login --use-device-code
-az acr build --subscription ${AZURE_SUBSCRIPTION_ID} --registry ${AZURE_CONTAINER_REGISTRY_NAME} --image creativeagentapi:${TAG} --file ./src/Dockerfile.fat ./src/
-image_name="${AZURE_CONTAINER_REGISTRY_NAME}.azurecr.io/creativeagentapi:${TAG}"
-az containerapp update --subscription ${AZURE_SUBSCRIPTION_ID} --name ${SERVICE_ACA_NAME} --resource-group ${AZURE_RESOURCE_GROUP} --image ${image_name}
-az containerapp ingress update --subscription ${AZURE_SUBSCRIPTION_ID} --name ${SERVICE_ACA_NAME} --resource-group ${AZURE_RESOURCE_GROUP} --target-port 5000
+acr_build () {
+    image_name=$1
+    aca_name=$2
+    src_dir=$3
+    target_port=$4
+    image_fqn="${AZURE_CONTAINER_REGISTRY_NAME}.azurecr.io/${image_name}"
+    echo  "Building ${image_name} using ${src_dir} ..."
+    az acr build --subscription ${AZURE_SUBSCRIPTION_ID} --registry ${AZURE_CONTAINER_REGISTRY_NAME} --image ${image_name} ${src_dir}
+    az containerapp update --subscription ${AZURE_SUBSCRIPTION_ID} --name ${aca_name} --resource-group ${AZURE_RESOURCE_GROUP} --image ${image_fqn}
+    az containerapp ingress update --subscription ${AZURE_SUBSCRIPTION_ID} --name ${aca_name} --resource-group ${AZURE_RESOURCE_GROUP} --target-port ${target_port}
+}
 
+TAG=$(date +%Y%m%d-%H%M%S)
+acr_build creativeagentapi:${TAG} ${API_SERVICE_ACA_NAME} ./src/api/ 80
+acr_build creativeagentweb:${TAG} ${WEB_SERVICE_ACA_NAME} ./src/web/ 8080
 
 # Retrieve service names, resource group name, and other values from environment variables
 resourceGroupName=$AZURE_RESOURCE_GROUP
@@ -30,7 +37,7 @@ fi
 azd env set AZURE_OPENAI_API_VERSION 2023-03-15-preview
 azd env set AZURE_OPENAI_CHAT_DEPLOYMENT gpt-35-turbo
 azd env set AZURE_SEARCH_ENDPOINT $AZURE_SEARCH_ENDPOINT
-azd env set REACT_APP_API_BASE_URL $image_name
+azd env set REACT_APP_API_BASE_URL $WEB_SERVICE_ACA_URI
 
 # Setup to run notebooks
 # Retrieve the internalId of the Cognitive Services account

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -203,6 +203,20 @@ module apiContainerApp 'app/api.bicep' = {
   }
 }
 
+module webContainerApp 'app/web.bicep' = {
+  name: 'web'
+  scope: resourceGroup
+  params: {
+    name: replace('${take(prefix, 18)}-web', '--', '-')
+    location: location
+    tags: tags
+    identityName: managedIdentity.outputs.managedIdentityName
+    identityId: managedIdentity.outputs.managedIdentityClientId
+    containerAppsEnvironmentName: containerApps.outputs.environmentName
+    containerRegistryName: containerApps.outputs.registryName
+  }
+}
+
 module aiSearchRole 'core/security/role.bicep' = {
   scope: resourceGroup
   name: 'ai-search-index-data-contributor'
@@ -286,9 +300,13 @@ output AZURE_OPENAI_NAME string = ai.outputs.openAiName
 output AZURE_OPENAI_RESOURCE_GROUP string = resourceGroup.name
 output AZURE_OPENAI_RESOURCE_GROUP_LOCATION string = resourceGroup.location
 
-output SERVICE_ACA_NAME string = apiContainerApp.outputs.SERVICE_ACA_NAME
-output SERVICE_ACA_URI string = apiContainerApp.outputs.SERVICE_ACA_URI
-output SERVICE_ACA_IMAGE_NAME string = apiContainerApp.outputs.SERVICE_ACA_IMAGE_NAME
+output API_SERVICE_ACA_NAME string = apiContainerApp.outputs.SERVICE_ACA_NAME
+output API_SERVICE_ACA_URI string = apiContainerApp.outputs.SERVICE_ACA_URI
+output API_SERVICE_ACA_IMAGE_NAME string = apiContainerApp.outputs.SERVICE_ACA_IMAGE_NAME
+
+output WEB_SERVICE_ACA_NAME string = webContainerApp.outputs.SERVICE_ACA_NAME
+output WEB_SERVICE_ACA_URI string = webContainerApp.outputs.SERVICE_ACA_URI
+output WEB_SERVICE_ACA_IMAGE_NAME string = webContainerApp.outputs.SERVICE_ACA_IMAGE_NAME
 
 output AZURE_CONTAINER_ENVIRONMENT_NAME string = containerApps.outputs.environmentName
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerApps.outputs.registryLoginServer

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -214,6 +214,7 @@ module webContainerApp 'app/web.bicep' = {
     identityId: managedIdentity.outputs.managedIdentityClientId
     containerAppsEnvironmentName: containerApps.outputs.environmentName
     containerRegistryName: containerApps.outputs.registryName
+    apiEndpoint: apiContainerApp.outputs.SERVICE_ACA_URI
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -157,7 +157,7 @@ module bing 'core/bing/bing-search.bicep' = {
   name: 'bing'
   scope: resourceGroup
   params: {
-    name: !empty(bingSearchName) ? bingSearchName : '${prefix}-bing-search-creative'
+    name: !empty(bingSearchName) ? bingSearchName : '${take(prefix, 64-12)}-bing-search'
     location: 'global'
   }
 }
@@ -170,7 +170,7 @@ module containerApps 'core/host/container-apps.bicep' = {
     name: 'app'
     location: location
     tags: tags
-    containerAppsEnvironmentName: '${prefix}-containerapps-env'
+    containerAppsEnvironmentName: '${take(replace(prefix, '--', '-'), 64-7)}-ca-env'
     containerRegistryName: ai.outputs.containerRegistryName
     logAnalyticsWorkspaceName: ai.outputs.logAnalyticsWorkspaceName
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -176,11 +176,11 @@ module containerApps 'core/host/container-apps.bicep' = {
   }
 }
 
-module aca 'app/aca.bicep' = {
-  name: 'aca'
+module apiContainerApp 'app/api.bicep' = {
+  name: 'api'
   scope: resourceGroup
   params: {
-    name: replace('${take(prefix, 19)}-ca', '--', '-')
+    name: replace('${take(prefix, 18)}-api', '--', '-')
     location: location
     tags: tags
     identityName: managedIdentity.outputs.managedIdentityName
@@ -286,9 +286,9 @@ output AZURE_OPENAI_NAME string = ai.outputs.openAiName
 output AZURE_OPENAI_RESOURCE_GROUP string = resourceGroup.name
 output AZURE_OPENAI_RESOURCE_GROUP_LOCATION string = resourceGroup.location
 
-output SERVICE_ACA_NAME string = aca.outputs.SERVICE_ACA_NAME
-output SERVICE_ACA_URI string = aca.outputs.SERVICE_ACA_URI
-output SERVICE_ACA_IMAGE_NAME string = aca.outputs.SERVICE_ACA_IMAGE_NAME
+output SERVICE_ACA_NAME string = apiContainerApp.outputs.SERVICE_ACA_NAME
+output SERVICE_ACA_URI string = apiContainerApp.outputs.SERVICE_ACA_URI
+output SERVICE_ACA_IMAGE_NAME string = apiContainerApp.outputs.SERVICE_ACA_IMAGE_NAME
 
 output AZURE_CONTAINER_ENVIRONMENT_NAME string = containerApps.outputs.environmentName
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerApps.outputs.registryLoginServer

--- a/src/Dockerfile.fat
+++ b/src/Dockerfile.fat
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine as ui
+FROM node:18-alpine AS ui
 WORKDIR /app
 
 # Copy package files and install dependencies
@@ -15,26 +15,17 @@ RUN npm run build
 # Use an official lightweight Python image.
 FROM python:3.11-slim
 
-# Set the working directory in the container
-WORKDIR /code
-
-# Copy just the requirements.txt file initially
-COPY api/requirements.txt ./
-
-# Install any needed packages specified in requirements.txt, including those in the WHL directory
-RUN pip3 install --no-cache-dir -r requirements.txt --find-links ./whl
-
-# Copy UI static files
-COPY --from=ui /app/dist ./static/
+WORKDIR /app
+COPY api/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
 
 ENV UI_FOLDER=../static
 ENV API_PREFIX=/api
 
-# Copy the rest of your application's source code
-COPY api/ .
+# Copy UI static files
+COPY --from=ui /app/dist ./static/
 
-# Make port 5000 available to the world outside this container
-EXPOSE 5000
+EXPOSE 80
 
-# Define the command to run your app using gunicorn
-ENTRYPOINT ["gunicorn", "-c", "gunicorn.conf.py", "api.app:app"]
+CMD ["fastapi", "run", "main.py", "--port", "80"]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -32,6 +32,7 @@ else:
         o.strip()
         for o in Path(Path(__file__).parent / "origins.txt").read_text().splitlines()
     ]
+    origins = ["*"]
 
 app.add_middleware(
     CORSMiddleware,

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -1,12 +1,27 @@
+# Build stage
+FROM node:20-alpine AS ui
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy the rest of your application's source code
+COPY . .
+
+# Build the project
+RUN npm run build
+
 FROM nginx:alpine
 
 WORKDIR /app
 
-COPY dist/* .
-COPY dist/assets/* ./assets/
+# Copy UI static files
+COPY --from=ui /app/dist/* ./
+COPY --from=ui /app/dist/assets/* ./assets/
 
-COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
+COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 8080
+EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -21,7 +21,8 @@ COPY --from=ui /app/dist/* ./
 COPY --from=ui /app/dist/assets/* ./assets/
 
 COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx/run_nginx.sh /bin/run_nginx.sh
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/run_nginx.sh"]

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="/favicon.svg">
     <title>Contoso Outdoor Creative</title>
+    <script type="text/javascript">/*INIT_SECTION*/</script>
   </head>
   <body class="bg-zinc-50 text-zinc-900">
     <div id="root" class="flex min-h-screen flex-col"></div>

--- a/src/web/nginx/nginx.conf
+++ b/src/web/nginx/nginx.conf
@@ -1,7 +1,7 @@
 server {
   listen       80;
   location / {
-    root   /usr/share/nginx/html;
+    root   /app;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html =404;
   }

--- a/src/web/nginx/run_nginx.sh
+++ b/src/web/nginx/run_nginx.sh
@@ -1,0 +1,2 @@
+sed -i "s,/\*INIT_SECTION\*/,window['endpoint']='${API_ENDPOINT}'," /app/index.html
+nginx -g "daemon off;"

--- a/src/web/src/constants.ts
+++ b/src/web/src/constants.ts
@@ -4,7 +4,10 @@ const hostname = window.location.hostname;
 const apiPort = 8000
 
 
-const endpoint = (hostname === 'localhost' || hostname === '127.0.0.1')
+const endpoint = 
+    // @ts-expect-error
+    window['endpoint'] ? window['endpoint']
+    : (hostname === 'localhost' || hostname === '127.0.0.1')
     ? `http://localhost:${apiPort}`
     : hostname.endsWith('github.dev') 
     ? `${githubDevSubsPort(hostname, apiPort)}/`


### PR DESCRIPTION
This PR allows to successfully deploy the api and web ACA containers and connect them together. Most of the changes were made to the web container side of things:
- postprovision fail fast with `set -e`
- Build node web app in Docker instead of depending on web app being built before `azd up`ing
- Copying nginx conf file at `/etc/nginx/conf.d/default.conf`
- nginx root now points to app static files
- Target port for web aca container is 80
- Web app constants script reads endpoint from window var first
- new `run_nginx.sh` nginx run script which injects API_ENDPOINT in index.html window var
- added `/*INIT_SECTION*/` javascript injection placeholder to `index.html`
- web Dockerfile uses modified `run_nginx.sh` script
- ACA web container gets injected with api container's endpoint
